### PR TITLE
rejecting tasks

### DIFF
--- a/ondemandpool.py
+++ b/ondemandpool.py
@@ -23,18 +23,18 @@ class OnDemandPool(rm.Pool):
             self.shrink_capacity = 0
             return shrink_amt
 
-    # do we want to pass in tasks or use self.running_tasks?
     def launch_task(self, tasks):
-        # run each task
+        # add the task to running_task if enough resources, or reject
         finished = []
         for task in tasks:
-            # add the task to running_task if enough resources, or reject
             if task.resource <= self.free_capacity:
                 self.free_capacity -= task.resource
                 self.running_tasks.append(task)
             else:
                 task.status = rm.Status.REJECTED
                 finished.append(task)
+
+        # run each task
         reclaimed = 0
         for task in self.running_tasks:
             task.execute()
@@ -42,6 +42,7 @@ class OnDemandPool(rm.Pool):
                 reclaimed += task.resource
                 task.status = rm.Status.FINISHED
                 finished.append(task)
+       
         # reclaim additional resources when done running tasks
         if self.shrink_left > 0:
             self.shrink_capacity += reclaimed

--- a/rm.py
+++ b/rm.py
@@ -62,10 +62,6 @@ class Pool(object):
     	return None
     	#???  Calculate the cost for one task ???
 
-    # # Do we want this?:
-    # def add_task(self, task):
-    #     self.tasks.append(task)
-
 class Task:
     def __init__(self, task_id, arrival_time, resource, runtime, pool, workload):
         self.id = task_id

--- a/rm.py
+++ b/rm.py
@@ -1,4 +1,5 @@
 import math;
+from enum import Enum
 
 # Define pool names
 POOL_RESERVED = 'reserved' # only for testing purpose
@@ -6,10 +7,12 @@ POOL_ON_DEMAND = 'on-demand'
 POOL_BURST = 'burst'
 POOL_VOLATILE = 'volatile'
 
-STATUS_FINISH = "FINISH"
-STATUS_FAILED = "FAILED"
-STATUS_WAITING = "WAITING"
-STATUS_RUNNING = "RUNNING"
+class Status(Enum):
+    WAITING = 0
+    RUNNING = 1
+    FINISHED = 2
+    REJECTED = -1
+    FAILED = -2
 
 class RM:
     def __init__(self, capacity):
@@ -73,7 +76,7 @@ class Task:
         self.runtime = runtime
         self.pool = pool
         self.workload = workload
-        self.status = STATUS_WAITING
+        self.status = Status.WAITING
 
     def execute(self):
         #update the self.remained_work

--- a/test/test_ondemandpool.py
+++ b/test/test_ondemandpool.py
@@ -48,6 +48,7 @@ class TestOnDemandPool(unittest.TestCase):
         self.assertEqual(task.status, Status.FINISHED)
 
     def test_launch_task_reject(self):
+        # test rejecting a task
         SHRINK_LEFT = 5
         pool = OnDemandPool(None, None)
         pool.shrink_left = SHRINK_LEFT

--- a/test/test_ondemandpool.py
+++ b/test/test_ondemandpool.py
@@ -3,7 +3,7 @@ import unittest
 import sys
 sys.path.insert(0, './..')
 
-from rm import Task
+from rm import Task, Status
 from ondemandpool import OnDemandPool
 
 class TestOnDemandPool(unittest.TestCase):
@@ -37,12 +37,31 @@ class TestOnDemandPool(unittest.TestCase):
         pool.shrink_left = SHRINK_LEFT
         TASK_RESOURCE = 2
         TASK_RUNTIME = 1
+        FREE_CAPACITY = 10
         task = Task(None, None, TASK_RESOURCE, TASK_RUNTIME, None, None)
         self.assertEqual(task.remained_work, task.resource)
         tasks = [task]
+        pool.free_capacity = FREE_CAPACITY
         finished = pool.launch_task(tasks)
         self.assertEqual(finished, tasks)
         self.assertEqual(pool.shrink_left, SHRINK_LEFT - task.resource)
+        self.assertEqual(task.status, Status.FINISHED)
+
+    def test_launch_task_reject(self):
+        SHRINK_LEFT = 5
+        pool = OnDemandPool(None, None)
+        pool.shrink_left = SHRINK_LEFT
+        TASK_RESOURCE = 5
+        TASK_RUNTIME = 1
+        FREE_CAPACITY = 2
+        task = Task(None, None, TASK_RESOURCE, TASK_RUNTIME, None, None)
+        self.assertEqual(task.remained_work, task.resource)
+        tasks = [task]
+        pool.free_capacity = FREE_CAPACITY
+        finished = pool.launch_task(tasks)
+        self.assertEqual(pool.shrink_left, SHRINK_LEFT)
+        self.assertEqual(task.status, Status.REJECTED)
+             
 
     def test_cost_long_task(self):
         # test cost for runtime longer than min
@@ -62,7 +81,7 @@ class TestOnDemandPool(unittest.TestCase):
         pool = OnDemandPool(OD_MIN_LEN, None)
         task = Task(None, None, TASK_RESOURCE, TASK_RUNTIME, None, None)
         cost = pool.cost(task)
-        self.assertEqual(cost, OD_MIN_LEN * TASK_RESOURCE)        
+        self.assertEqual(cost, OD_MIN_LEN * TASK_RESOURCE) 
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I changed launch_task to add the task and first check if it has enough resources, and reject if not.
I also changed the status to enum instead of string so we don't have to import all of them separately.